### PR TITLE
Be/update update

### DIFF
--- a/ada-project-docs/wave_01.md
+++ b/ada-project-docs/wave_01.md
@@ -145,7 +145,6 @@ As a client, I want to be able to make a `PUT` request to `/tasks/1` when there 
 {
   "title": "Updated Task Title",
   "description": "Updated Test Description",
-  "completed_at": null
 }
 ```
 
@@ -164,6 +163,8 @@ and get this response:
 }
 ```
 
+Note that the update endpoint does update the `completed_at` attribute. This will be updated with custom endpoints implemented in Wave 03.
+
 ### Update Task: No Matching Task
 
 As a client, I want to be able to make a `PUT` request to `/tasks/1` when there are no matching tasks with this request body:
@@ -172,7 +173,6 @@ As a client, I want to be able to make a `PUT` request to `/tasks/1` when there 
 {
   "title": "Updated Task Title",
   "description": "Updated Test Description",
-  "completed_at": null
 }
 ```
 

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -89,7 +89,6 @@ def test_update_task(client, one_task):
     response = client.put("/tasks/1", json={
         "title": "Updated Task Title",
         "description": "Updated Test Description",
-        "completed_at": None
     })
     response_body = response.get_json()
 
@@ -115,7 +114,6 @@ def test_update_task_not_found(client):
     response = client.put("/tasks/1", json={
         "title": "Updated Task Title",
         "description": "Updated Test Description",
-        "completed_at": None
     })
     response_body = response.get_json()
 


### PR DESCRIPTION
A small change to remove the "completed at" attribute from the request body from of an Update. Being able to update with a traditional update given that the response body diluted information about when the task was complete caused trickiness in implementing the CLI. Also, the "completed at" attribute is updated through the mark complete and mark incomplete custom routes.