### PR TITLE
Add expire_session and blinker

### DIFF
--- a/ada-project-docs/wave_01.md
+++ b/ada-project-docs/wave_01.md
@@ -10,7 +10,7 @@ Tasks are entities that describe a task a user wants to complete. They contain a
 - description to hold details about the task
 - an optional datetime that the task is completed on
 
-Our goal for this wave is to be able to create, read, update, and delete different tasks.
+Our goal for this wave is to be able to create, read, update, and delete different tasks. We will create RESTful routes for this different operations.
 
 # Requirements
 

--- a/ada-project-docs/wave_05.md
+++ b/ada-project-docs/wave_05.md
@@ -8,7 +8,7 @@ Goals are entities that describe a task a user wants to complete.
 
 They contain a title to name the goal.
 
-Our goal for this wave is to be able to create, read, update, and delete different goals.
+Our goal for this wave is to be able to create, read, update, and delete different goals. We will create RESTful routes for these different operations.
 
 ## Writing Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.5.4
 attrs==20.3.0
 autopep8==1.5.5
+blinker==1.4
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,17 @@ from app.models.task import Task
 from app.models.goal import Goal
 from app import db
 from datetime import datetime
+from flask.signals import request_finished
 
 
 @pytest.fixture
 def app():
     # create the app with a test config dictionary
     app = create_app({"TESTING": True})
+
+    @request_finished.connect_via(app)
+    def expire_session(sender, response, **extra):
+        db.session.remove()
 
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
Add `expire_all` so that the checks of the database changes really check whether the database has changed.

@anselrognlie, ah, this is where I got the `expire_all` from! https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session.expire_all