### PR TITLE
Update Wave docs to use `204 No Content` where appropriate

### DIFF
--- a/ada-project-docs/wave_01.md
+++ b/ada-project-docs/wave_01.md
@@ -150,18 +150,9 @@ As a client, I want to be able to make a `PUT` request to `/tasks/1` when there 
 
 and get this response:
 
-`200 OK`
+`204 No Content`
 
-```json
-{
-  "task": {
-    "id": 1,
-    "title": "Updated Task Title",
-    "description": "Updated Test Description",
-    "is_complete": false
-  }
-}
-```
+The response should have a mimetype of "application/json" to keep our API response type consistent.
 
 Note that the update endpoint does update the `completed_at` attribute. This will be updated with custom endpoints implemented in Wave 3.
 
@@ -169,13 +160,9 @@ Note that the update endpoint does update the `completed_at` attribute. This wil
 
 As a client, I want to be able to make a `DELETE` request to `/tasks/1` when there is at least one saved task and get this response:
 
-`200 OK`
+`204 No Content`
 
-```json
-{
-  "details": "Task 1 \"Go on my daily walk 🏞\" successfully deleted"
-}
-```
+The response should have a mimetype of "application/json" to keep our API response type consistent.
 
 #### No Matching Task: Get, Update, and Delete
 

--- a/ada-project-docs/wave_03.md
+++ b/ada-project-docs/wave_03.md
@@ -38,7 +38,7 @@ then the task is updated, so that its `completed_at` value is the current date, 
 
 The response should have a mimetype of "application/json" to keep our API response type consistent.
 
-If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+After I have made the `PATCH` request, I can submit a `GET` request to `/tasks/1`, which will return the response:
 
 `200 OK`
 
@@ -68,7 +68,7 @@ then the task is updated, so that its `completed_at` value is `null`/`None`, and
 
 The response should have a mimetype of "application/json" to keep our API response type consistent.
 
-If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+After I have made the `PATCH` request, I can submit a `GET` request to `/tasks/1`, which will return the response:
 
 `200 OK`
 
@@ -98,7 +98,7 @@ then I want this to behave exactly like `/tasks/1/mark_complete` for an incomple
 
 The response should have a mimetype of "application/json" to keep our API response type consistent.
 
-If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+After I have made the `PATCH` request, I can submit a `GET` request to `/tasks/1`, which will return the response:
 
 `200 OK`
 
@@ -128,7 +128,7 @@ then I want this to behave exactly like `/tasks/1/mark_incomplete` for a complet
 
 The response should have a mimetype of "application/json" to keep our API response type consistent.
 
-If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+After I have made the `PATCH` request, I can submit a `GET` request to `/tasks/1`, which will return the response:
 
 `200 OK`
 

--- a/ada-project-docs/wave_03.md
+++ b/ada-project-docs/wave_03.md
@@ -34,6 +34,12 @@ when I send a `PATCH` request to `/tasks/1/mark_complete`,
 
 then the task is updated, so that its `completed_at` value is the current date, and I get this response:
 
+`204 No Content`
+
+The response should have a mimetype of "application/json" to keep our API response type consistent.
+
+If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+
 `200 OK`
 
 ```json
@@ -57,6 +63,12 @@ Given a task that has:
 when I send a `PATCH` request to `/tasks/1/mark_incomplete`,
 
 then the task is updated, so that its `completed_at` value is `null`/`None`, and I get this response:
+
+`204 No Content`
+
+The response should have a mimetype of "application/json" to keep our API response type consistent.
+
+If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
 
 `200 OK`
 
@@ -82,6 +94,12 @@ when I send a `PATCH` request to `/tasks/1/mark_complete`,
 
 then I want this to behave exactly like `/tasks/1/mark_complete` for an incomplete task. The task is updated, so that its `completed_at` value is the current date, and I get this response:
 
+`204 No Content`
+
+The response should have a mimetype of "application/json" to keep our API response type consistent.
+
+If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
+
 `200 OK`
 
 ```json
@@ -105,6 +123,12 @@ Given a task that has:
 when I send a `PATCH` request to `/tasks/1/mark_incomplete`,
 
 then I want this to behave exactly like `/tasks/1/mark_incomplete` for a complete task. Its `completed_at` value remains as `null`/`None`, and I get this response:
+
+`204 No Content`
+
+The response should have a mimetype of "application/json" to keep our API response type consistent.
+
+If after the `PATCH` request I fetch the task by sending a `GET` request to `/tasks/1`, I get this response:
 
 `200 OK`
 

--- a/ada-project-docs/wave_05.md
+++ b/ada-project-docs/wave_05.md
@@ -125,28 +125,17 @@ As a client, I want to be able to make a `PUT` request to `/goals/1` when there 
 
 and get this response:
 
-`200 OK`
+`204 No Content`
 
-```json
-{
-  "goal": {
-    "id": 1,
-    "title": "Updated Goal Title"
-  }
-}
-```
+The response should have a mimetype of "application/json" to keep our API response type consistent.
 
 ### Delete Goal: Deleting a Goal
 
 As a client, I want to be able to make a `DELETE` request to `/goals/1` when there is at least one saved goal and get this response:
 
-`200 OK`
+`204 No Content`
 
-```json
-{
-  "details": "Goal 1 \"Build a habit of going outside daily\" successfully deleted"
-}
-```
+The response should have a mimetype of "application/json" to keep our API response type consistent.
 
 ### No matching Goal: Get, Update, and Delete
 


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1205655776549324/1208760575601152)

Update Wave docs to reflect that PUT/PATCH/DELETE endpoints should use `204 No Content` as the expected response.

**This PR addresses the wave documents, the tests for the affected endpoints are being updated in a separate PR that will also update the tests to use the newer DB syntax.**


