### PR TITLE
Remove literal quotes around bearer token in wave 4 doc 

### DIFF
--- a/ada-project-docs/wave_04.md
+++ b/ada-project-docs/wave_04.md
@@ -141,7 +141,7 @@ Open Postman and make a request that mimics the API call to Slack that we just t
 ![](assets/postman_request_body.png)
 
 - In "Headers," add this new key-value pair:
-  - `Authorization`: `"Bearer xoxb-150..."`, where `xoxb-150...` is your full Slackbot token
+  - `Authorization`: `Bearer xoxb-150...`, where `xoxb-150...` is your full Slackbot token
 
 ![](assets/postman_headers.png)
 


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1210413875981109?focus=true)

Change:
Remove literal quotes around bearer token in wave 4 doc that can be misleading and cause extra troubleshooting if students include them